### PR TITLE
Changed name of current sound to var

### DIFF
--- a/Source/AudioPlayer.swift
+++ b/Source/AudioPlayer.swift
@@ -33,7 +33,7 @@ public class AudioPlayer: NSObject {
     public typealias SoundCompletionHandler = (didFinish: Bool) -> Void
     
     /// Name of the used to initialize the object
-    public let name: String?
+    public var name: String?
 
     /// URL of the used to initialize the object
     public let URL: NSURL?


### PR DESCRIPTION
Changed name of current sound to var so that it is possible to compare it to a custom variable to see which sounds is currently initialized.
