### PR TITLE
Adds the ability to initialize the player with Data

### DIFF
--- a/AudioPlayerSwift/AudioPlayerSwift iOS/AudioPlayerSwiftTests.swift
+++ b/AudioPlayerSwift/AudioPlayerSwift iOS/AudioPlayerSwiftTests.swift
@@ -54,6 +54,34 @@ extension AudioPlayerSwiftTests {
         }
     }
 
+    func testInit_withValidData(){
+        guard let path = soundPath else {
+            XCTFail("Unable to continue, 'soundPath'")
+            return
+        }
+
+        let data = try! Data(contentsOf: URL(fileURLWithPath: path))
+
+        do {
+            _ = try AudioPlayer(data: data)
+            XCTAssertTrue(true)
+        } catch {
+            XCTAssertTrue(false)
+        }
+    }
+
+    func testInvalidData(){
+
+        let data = Data()
+
+        do {
+            _ = try AudioPlayer(data: data)
+            XCTAssertTrue(false)
+        } catch {
+            XCTAssertTrue(true)
+        }
+    }
+
 }
 
 // MARK: Sound State

--- a/Source/AudioPlayer.swift
+++ b/Source/AudioPlayer.swift
@@ -137,6 +137,14 @@ public class AudioPlayer: NSObject {
         sound?.delegate = self
     }
 
+    public init(data: Data, name: String = "AudioData") throws {
+        self.name = name
+        self.url = nil
+        sound = try AVAudioPlayer(data: data)
+        super.init()
+        sound?.delegate = self
+    }
+
     deinit {
         timer?.invalidate()
         sound?.delegate = nil


### PR DESCRIPTION
`AVAudioPlayer` provides a data initialization. So in a similar vein to the other AudioPlayer initializers, this provides a wrapper around `AVAudioPlayer`'s data initializer.

This is useful when dealing with audio from sources like `FileWrapper` which only allows access to `Data` not a `URL`.