### PR TITLE
Ensures the Timer is scheduled on the main thread

### DIFF
--- a/AudioPlayerSwift/AudioPlayerSwift iOS/AudioPlayerSwiftTests.swift
+++ b/AudioPlayerSwift/AudioPlayerSwift iOS/AudioPlayerSwiftTests.swift
@@ -100,3 +100,26 @@ extension AudioPlayerSwiftTests {
         audioPlayer?.stop()
     }
 }
+
+// MARK: Threading
+extension AudioPlayerSwiftTests {
+
+    func testTimerInvokedOnMainThread(){
+
+        let name = AudioPlayer.SoundDidFinishPlayingNotification
+        let done = expectation(description: "done")
+
+        // qos' default value is ´DispatchQoS.QoSClass.default`
+        DispatchQueue.global().async {
+            self.audioPlayer?.play()
+            self.audioPlayer?.fadeOut(duration: 0.2)
+        }
+
+        NotificationCenter.default.addObserver(forName: name, object: nil, queue: nil) { _ in
+            XCTAssertTrue(true)
+            done.fulfill()
+        }
+
+        waitForExpectations(timeout: 2, handler: nil)
+    }
+}

--- a/Source/AudioPlayer.swift
+++ b/Source/AudioPlayer.swift
@@ -166,7 +166,9 @@ public class AudioPlayer: NSObject {
         fadeTime = duration
         fadeStart = NSDate().timeIntervalSinceReferenceDate
         if timer == nil {
-            timer = Timer.scheduledTimer(timeInterval: 0.015, target: self, selector: #selector(handleFadeTo), userInfo: nil, repeats: true)
+            DispatchQueue.main.async {
+                self.timer = Timer.scheduledTimer(timeInterval: 0.015, target: self, selector: #selector(self.handleFadeTo), userInfo: nil, repeats: true)
+            }
         }
     }
 


### PR DESCRIPTION
This actually got me. I was invoking a `fadeTo` as the result of a message from an XPC service and it wasn't working. The Timer needs to be scheduled on the main thread. This ensures that is the case.