### PR TITLE
Improve SoundDidFinishPlayingNotification by including completion success in notification

### DIFF
--- a/AudioPlayerSwift Examples/iOS Example/ViewController.swift
+++ b/AudioPlayerSwift Examples/iOS Example/ViewController.swift
@@ -26,8 +26,18 @@ class ViewController: UIViewController {
         } catch {
             print("Sound initialization failed")
         }
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(handleCompletion(_:)), name: AudioPlayer.SoundDidFinishPlayingNotification, object: nil)
     }
 
+    func handleCompletion(_ notification:Notification) {
+        let audioPlayer = notification.object as! AudioPlayer
+        if let name = audioPlayer.name,
+           let success = notification.userInfo?[AudioPlayer.SoundDidFinishPlayingSuccessfully] {
+            print("AudioPlayer with name '\(name)' did finish playing with success: \(success)")
+        }
+    }
+    
     // MARK: IBAction
 
     @IBAction func playSound1Pressed(sender: AnyObject) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ N/A
 
 - Swift 4 and Xcode 9 support
 - Swift 4.2 and Xcode 10 support
+- SoundDidFinishPlayingNotification now includes SoundDidFinishPlayingSuccessfully boolean in the notification's userInfo
 
 #### Bugfixes
 

--- a/Sources/AudioPlayer.swift
+++ b/Sources/AudioPlayer.swift
@@ -114,9 +114,8 @@ public class AudioPlayer: NSObject {
     // MARK: Init
 
     public convenience init(fileName: String) throws {
-        let fixedFileName = fileName.trimmingCharacters(in: .whitespacesAndNewlines)
-        var soundFileComponents = fixedFileName.components(separatedBy: ".")
-        if soundFileComponents.count == 1 {
+        let soundFileComponents = fileName.trimmingCharacters(in: .whitespacesAndNewlines).components(separatedBy: ".")
+        guard soundFileComponents.count == 2 else {
             throw AudioPlayerError.fileExtension
         }
 

--- a/Sources/AudioPlayer.swift
+++ b/Sources/AudioPlayer.swift
@@ -120,10 +120,10 @@ public class AudioPlayer: NSObject {
             throw AudioPlayerError.fileExtension
         }
 
-        guard let path = Bundle.main.path(forResource: soundFileComponents[0], ofType: soundFileComponents[1]) else {
+        guard let url = Bundle.main.url(forResource: soundFileComponents[0], withExtension: soundFileComponents[1]) else {
             throw AudioPlayerError.fileNotFound
         }
-        try self.init(contentsOfPath: path)
+        try self.init(contentsOf: url)
     }
 
     public convenience init(contentsOfPath path: String) throws {

--- a/Sources/AudioPlayer.swift
+++ b/Sources/AudioPlayer.swift
@@ -30,6 +30,7 @@ public enum AudioPlayerError: Error {
 public class AudioPlayer: NSObject {
 
     public static let SoundDidFinishPlayingNotification = Notification.Name(rawValue: "SoundDidFinishPlayingNotification")
+    public static let SoundDidFinishPlayingSuccessfully = "success"
     public typealias SoundDidFinishCompletion = (_ didFinish: Bool) -> Void
 
     // MARK: Properties
@@ -223,7 +224,8 @@ extension AudioPlayer: AVAudioPlayerDelegate {
             nonNilCompletionHandler(flag)
         }
 
-        NotificationCenter.default.post(name: AudioPlayer.SoundDidFinishPlayingNotification, object: self)
+        let success = [ AudioPlayer.SoundDidFinishPlayingSuccessfully: flag ]
+        NotificationCenter.default.post(name: AudioPlayer.SoundDidFinishPlayingNotification, object: self, userInfo: success)
     }
 
 }


### PR DESCRIPTION
Modules wanting to be notified about the completion of an AudioPlayer playing a sound have two options:
1. Provide completion handler, but only be notified about whether play completed successfully
2. Register for NotificationCenter, but only be notified about the player that completed

This creates an issue when the module wants to do something specifically based on the completion success while not knowing which of potentially multiple AudioPlayers is sending the message.

Fixing #1 requires changing the method signature. While I would encourage this to be implemented as it makes the completion handler more powerful, it will break the current API. 

Fixing #2 is easy and non-breaking. I have implemented this here by adding a userInfo dictionary to the Notification including the boolean completion success.

---

I have also made a few small code changes to the init methods to use best Swift practices.