### PR TITLE
Update swift package spec to work with Xcode 12

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,6 @@
+// swift-tools-version:5.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -21,6 +21,7 @@ let package = Package(
       // Targets are the basic building blocks of a package. A target can define a module or a test suite.
       // Targets can depend on other targets in this package, and on products in packages this package depends on.
       .target(
-        name: "AudioPlayer")
+        name: "AudioPlayer",
+        path: "Sources")
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,10 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.4
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
-  name: "AudioPlayer"
+  name: "AudioPlayer",
   
   platforms: [
     .iOS(.v12),

--- a/Package.swift
+++ b/Package.swift
@@ -5,4 +5,22 @@ import PackageDescription
 
 let package = Package(
   name: "AudioPlayer"
+  
+  platforms: [
+    .iOS(.v12),
+    .tvOS(.v12),
+    .macOS(.v11)
+  ],
+  products: [
+    // Products define the executables and libraries a package produces, and make them visible to other packages.
+    .library(
+      name: "AudioPlayer",
+      targets: ["AudioPlayer"])
+    ],
+    targets: [
+      // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+      // Targets can depend on other targets in this package, and on products in packages this package depends on.
+      .target(
+        name: "AudioPlayer"
+    ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -21,6 +21,6 @@ let package = Package(
       // Targets are the basic building blocks of a package. A target can define a module or a test suite.
       // Targets can depend on other targets in this package, and on products in packages this package depends on.
       .target(
-        name: "AudioPlayer"
+        name: "AudioPlayer")
     ]
 )


### PR DESCRIPTION
In trying to bring the AudioPlayer package into my current project I found that Xcode 12 was pretty unhappy with the spec, so I've filled it in.